### PR TITLE
fix errors in coupled parameter sweep script

### DIFF
--- a/poc_abm_cfd.sh
+++ b/poc_abm_cfd.sh
@@ -7,7 +7,7 @@
 BIOCELLION_MODEL_PATH="/home/jaroknor/NLeSC/InSilicoMeat/Biocellion/Biocellion-3.1/biocellion-3.1/biocellion-user/ABM-microcarriers"
 PARAMETER_FILE="${BIOCELLION_MODEL_PATH}/Parameters-ABM-CFD.csv"
 
-# Set the number of steps to check for completion of old simulations (will not be used to run the new simulations!)
+# Set the number of steps to check for completion of old simulations (will not be used to run the new simulations, this should be set by hand in run_model.xml!)
 NSTEPS_CHECK=120000
 
 # extract the parameters from the spreadsheet (skips the first 4 header lines)


### PR DESCRIPTION
Two columns in the csv file where switch with respect to the ABM only table, which made the script enter the wrong values in the model. Also introduced the number of steps to check for as a variable. The coupled simulations should run 120000 steps. This can now be set. It will not change the actual simulation but only check the previous output for being complete. 